### PR TITLE
Allow one click per tick while the portal is closed

### DIFF
--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
@@ -79,6 +79,10 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 	private static final String REWARD_POINT_REGEX = "Elemental attunement level:[^>]+>(\\d+).*Catalytic attunement level:[^>]+>(\\d+)";
 	private static final Pattern REWARD_POINT_PATTERN = Pattern.compile(REWARD_POINT_REGEX);
 
+	private static final int BARRIER_DIALOG_WIDGET_GROUP = 229;
+	private static final int BARRIER_DIALOG_WIDGET_MESSAGE = 1;
+	private static final String BARRIER_DIALOG_FINISHING_UP = "It looks like the adventurers within are just finishing up. You must<br>wait until they are done to join.";
+
 	@Getter(AccessLevel.PACKAGE)
 	private final Set<GameObject> guardians = new HashSet<>();
 	@Getter(AccessLevel.PACKAGE)
@@ -229,6 +233,16 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 			}
 			portalLocation = null;
 			portalSpawnTime = Optional.empty();
+		}
+
+		Widget barrierDialog = client.getWidget(BARRIER_DIALOG_WIDGET_GROUP, BARRIER_DIALOG_WIDGET_MESSAGE);
+		if (barrierDialog != null)
+		{
+			String barrierText = barrierDialog.getText();
+			if (barrierText.equals(BARRIER_DIALOG_FINISHING_UP)) {
+				// Allow one click per tick while the portal is closed
+				entryBarrierClickCooldown = 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
Sorry, me again. After some more testing I realised PR #5 causes an unnecessary delay when spam clicking while the portal is closed, which could potentially also lead to being left out of the game... Oops. This PR checks for a known string in a message dialog box widget that appears when clicking on the yellow version of the barrier when the previous game is ending. If the message is spotted, the cooldown is reset, allowing one click per tick instead of every 3 ticks.