### PR TITLE
mute the over head game help messages

### DIFF
--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
@@ -30,6 +30,16 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
     }
 
     @ConfigItem(
+            keyName = "muteApprentices",
+            name = "Mute game help messages",
+            description = "Mutes the over head messages of the apprentices giving game advice."
+    )
+    default boolean muteApprentices()
+    {
+        return true;
+    }
+
+    @ConfigItem(
             keyName = "outlineCellTable",
             name = "Outline cell table",
             description = "Outlines the Cell table when you have no cells remaining."

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
@@ -382,4 +382,17 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 			}
 		}
 	}
+
+	@Subscribe
+	public void onOverheadTextChanged(OverheadTextChanged event)
+	{
+		if (!("Apprentice Tamara".equals(event.getActor().getName()) || "Apprentice Cordelia".equals(event.getActor().getName())))
+		{
+			return;
+		}
+		if (config.muteApprentices())
+		{
+			event.getActor().setOverheadText(" ");
+		}
+	}
 }


### PR DESCRIPTION
When toggled on this option mutes the game help messages from the apprentices wandering around.
New pull request with just the mute change.