### PR TITLE
add changing color to time since portal text

### DIFF
--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPanel.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPanel.java
@@ -51,6 +51,7 @@ public class GuardiansOfTheRiftHelperPanel extends OverlayPanel {
             panelComponent.getChildren().add(LineComponent.builder()
                     .left("Time since portal:")
                     .right(""+timeSincePortal)
+                    .rightColor(plugin.getTimeSincePortalColor(timeSincePortal))
                     .build());
         }
 

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
@@ -18,6 +18,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
+import java.awt.Color;
 import java.time.Instant;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -110,6 +111,8 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 	private boolean outlineUnchargedCellTable = false;
 	@Getter(AccessLevel.PACKAGE)
 	private boolean shouldMakeGuardian = false;
+	@Getter(AccessLevel.PACKAGE)
+	private boolean isFirstPortal = false;
 
 	@Getter(AccessLevel.PACKAGE)
 	private int elementalRewardPoints;
@@ -221,6 +224,9 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 		if(portalWidget != null && !portalWidget.isHidden()){
 			if(!portalSpawnTime.isPresent() && lastPortalDespawnTime.isPresent()) {
 				lastPortalDespawnTime = Optional.empty();
+				if (isFirstPortal) {
+					isFirstPortal = false;
+				}
 				if(config.notifyPortalSpawn()){
 					notifier.notify("A portal has spawned in the " + portalWidget.getText() + ".");
 				}
@@ -328,6 +334,7 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 		if(msg.contains("The rift becomes active!")) {
 			lastPortalDespawnTime = Optional.of(Instant.now());
 			nextGameStart = Optional.empty();
+			isFirstPortal = true;
 		} else if(msg.contains("The rift will become active in 30 seconds.")) {
 			nextGameStart = Optional.of(Instant.now().plusSeconds(30));
 		} else if(msg.contains("The rift will become active in 10 seconds.")) {
@@ -368,7 +375,7 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
 		if(!config.quickPassCooldown()) return;
-		
+
 		// Only allow one click on the entry barrier's quick-pass option for every 3 game ticks
 		if (event.getId() == 43700 && event.getMenuAction().getId() == 5)
 		{
@@ -395,4 +402,23 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 			event.getActor().setOverheadText(" ");
 		}
 	}
+
+	public Color getTimeSincePortalColor(int timeSincePortal)
+	{
+		if (isFirstPortal)
+		{
+			// first portal takes about 40 more seconds to spawn
+			timeSincePortal -= 40;
+		}
+		if (timeSincePortal >= 108)
+		{
+			return Color.RED;
+		}
+		else if(timeSincePortal >= 85)
+		{
+			return Color.YELLOW;
+		}
+		return Color.GREEN;
+	}
 }
+


### PR DESCRIPTION
This changes the color of the time since portal text. The color starts as green but as the portal gets closer to spawning changes to yellow and then red. I tried to have the color change to yellow when you should be running to craft runes in order to comfortably make the portal. These numbers can probably be tweaked or maybe even add a config.

![image](https://user-images.githubusercontent.com/85463994/161534168-edd9bf34-633a-4e52-b445-266f61d33646.png)
