### PR TITLE
capture singular point properly in reward refresh

### DIFF
--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
@@ -80,7 +80,7 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 
 	private static final String REWARD_POINT_REGEX = "Elemental attunement level:[^>]+>(\\d+).*Catalytic attunement level:[^>]+>(\\d+)";
 	private static final Pattern REWARD_POINT_PATTERN = Pattern.compile(REWARD_POINT_REGEX);
-	private static final String CHECK_POINT_REGEX = "You have (\\d+) catalytic points and (\\d+) elemental points";
+	private static final String CHECK_POINT_REGEX = "You have (\\d+) catalytic points? and (\\d+) elemental points?";
 	private static final Pattern CHECK_POINT_PATTERN = Pattern.compile(CHECK_POINT_REGEX);
 
 	private static final int DIALOG_WIDGET_GROUP = 229;


### PR DESCRIPTION
The current regex doesn't capture reward text that includes a singular point in either catalytic or elemental. This modifies the regex to match 'point' singular and plural.