### PR TITLE
Fix leading zeroes in points potential

### DIFF
--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPanel.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPanel.java
@@ -76,7 +76,7 @@ public class GuardiansOfTheRiftHelperPanel extends OverlayPanel {
 			final int potCatalyticPoints = potentialPoints(plugin.getCatalyticRewardPoints(), plugin.getCurrentCatalyticRewardPoints());
 			final int elementalRemain = plugin.getCurrentElementalRewardPoints() % 100;
 			final int catalyticRemain = plugin.getCurrentCatalyticRewardPoints() % 100;
-			final String potPoints = potElementalPoints + "." + elementalRemain + "/" + potCatalyticPoints + "." + catalyticRemain;
+			final String potPoints = String.format("%d.%02d/%d.%02d", potElementalPoints, elementalRemain, potCatalyticPoints, catalyticRemain);
 			Color potColor = Color.WHITE;
 			if (config.highlightPotential())
 			{


### PR DESCRIPTION
Currently if you have less than 10 points over a multiple of 100, the potential points will render incorrectly due to lack of leading zeroes. For example if you have 208 elemental points in your current game and 14 saved, your potential points will render as 16.8 instead of the correct 16.08. Fixed with a format string.