### PR TITLE
Add inactive portal overlay

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.33'
+def runeLiteVersion = '1.9.10'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.datbear'
-version = '1.02'
+version = '1.1'
 sourceCompatibility = "1.8"
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
@@ -19,24 +19,13 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
 	String outlines = "outlines";
 
 	@ConfigSection(
-		name = "Overlay",
-		description = "All options relating to the overlay",
+		name = "Overlays",
+		description = "All options relating to overlays",
 		position =  1,
 		closedByDefault = true
 
 	)
-	String overlay = "overlay";
-
-    @ConfigItem(
-			keyName = "showOverlay",
-			name = "Show Overlay",
-			description = "Toggles the status overlay.",
-			section = overlay
-    )
-    default boolean showOverlay()
-    {
-        return true;
-    }
+	String overlays = "overlays";
 
     @ConfigItem(
             keyName = "portalSpawn",
@@ -172,12 +161,48 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
         return Color.RED;
     }
 
+    @ConfigItem(
+            keyName = "showStartTimerOverlay",
+            name = "Show Start Timer Overlay",
+            description = "Toggles the start timer overlay.",
+            position =  7,
+            section = overlays
+    )
+    default boolean showStartTimerOverlay()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "showInactivePortalOverlay",
+            name = "Show Inactive Portal Overlay",
+            description = "Toggles the inactive portal overlay.",
+            position =  8,
+            section = overlays
+    )
+    default boolean showInactivePortalOverlay()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "showPointsOverlay",
+            name = "Show Points Overlay",
+            description = "Toggles the points overlay.",
+            position =  9,
+            section = overlays
+    )
+    default boolean showPointsOverlay()
+    {
+        return true;
+    }
+
 	@ConfigItem(
 		keyName = "potentialPoints",
 		name = "Show potential points",
 		description = "Show tallied up points during a game",
-		position =  7,
-		section = overlay
+		position =  10,
+		section = overlays
 	)
 	default boolean potentialPoints() { return true; }
 
@@ -185,8 +210,8 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
 		keyName = "highlightPotential",
 		name = "Highlight potential points",
 		description =  "Highlight potential points depending on balance",
-		position =  8,
-		section = overlay
+		position =  11,
+		section = overlays
 	)
 	default boolean highlightPotential() { return true; }
 
@@ -194,8 +219,8 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
 		keyName = "potentialUnbalanceColor",
 		name = "Unbalanced potential color",
 		description =  "Color to highlight potential points when unbalanced",
-		position = 9,
-		section = overlay
+		position = 12,
+		section = overlays
 	)
 	default Color potentialUnbalanceColor() { return Color.RED; }
 
@@ -203,8 +228,8 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
 		keyName = "potentialBalanceColor",
 		name = "Balanced potential color",
 		description =  "Color to highlight potential points when balanced",
-		position =  10,
-		section = overlay
+		position =  13,
+		section = overlays
 	)
 	default Color potentialBalanceColor() { return Color.GREEN; }
 }

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperInactivePortalOverlay.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperInactivePortalOverlay.java
@@ -1,0 +1,85 @@
+package com.datbear;
+
+import net.runelite.api.Client;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.game.SpriteManager;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.util.ImageUtil;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+public class GuardiansOfTheRiftHelperInactivePortalOverlay extends Overlay {
+    private Client client;
+    private GuardiansOfTheRiftHelperPlugin plugin;
+    private GuardiansOfTheRiftHelperConfig config;
+    private SpriteManager spriteManager;
+
+    @Inject
+    public GuardiansOfTheRiftHelperInactivePortalOverlay(Client client, GuardiansOfTheRiftHelperPlugin plugin, GuardiansOfTheRiftHelperConfig config, SpriteManager spriteManager) {
+        super(plugin);
+        this.client = client;
+        this.plugin = plugin;
+        this.config = config;
+        this.spriteManager = spriteManager;
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        if ((!plugin.isInMainRegion() && !plugin.isInMinigame()) || !config.showInactivePortalOverlay()) {
+            return null;
+        }
+
+        Widget parentWidget = client.getWidget(plugin.getParentWidgetId());
+        Widget portalWidget = client.getWidget(plugin.getPortalWidgetId());
+
+        if (parentWidget == null || portalWidget == null) {
+            return null;
+        }
+
+        if (parentWidget.isHidden()) {
+            return null;
+        }
+
+        if (!portalWidget.isHidden()) {
+            return null;
+        }
+
+        BufferedImage image = spriteManager.getSprite(plugin.getPortalSpriteId(), 0);
+        image = ImageUtil.grayscaleImage(image);
+
+        int x = 189;
+        int y = 70;
+        int width = 32;
+        int height = 32;
+
+        graphics.drawImage(image, x, y, width, height, null);
+
+        Optional<Instant> despawn = plugin.getLastPortalDespawnTime();
+
+        // simulates the delay that the widget has for the initial text
+        if (plugin.isFirstPortal())
+        {
+            int timeSincePortalMillis = despawn.isPresent() ? ((int)(ChronoUnit.MILLIS.between(despawn.get(), Instant.now()))) : 0;
+            if (timeSincePortalMillis < 1200) {
+                return null;
+            }
+        }
+
+        int timeSincePortal = despawn.isPresent() ? ((int)(ChronoUnit.SECONDS.between(despawn.get(), Instant.now()))) : 0;
+        String mins = String.format("%01d", timeSincePortal / 60);
+        String secs = String.format("%02d", timeSincePortal % 60);
+        String text = mins + ":" + secs;
+
+        int textHeight = 24;
+        Rectangle rect = new Rectangle(x, y + height, width, textHeight);
+
+        plugin.drawCenteredString(graphics, text, rect);
+
+        return null;
+    }
+}

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPanel.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPanel.java
@@ -8,9 +8,6 @@ import net.runelite.client.ui.overlay.components.LineComponent;
 
 import javax.inject.Inject;
 import java.awt.*;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Optional;
 
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
 import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
@@ -41,29 +38,9 @@ public class GuardiansOfTheRiftHelperPanel extends OverlayPanel {
     @Override
     public Dimension render(Graphics2D graphics)
     {
-        if((!plugin.isInMainRegion() && !plugin.isInMinigame()) || !config.showOverlay()){
+        if((!plugin.isInMainRegion() && !plugin.isInMinigame()) || !config.showPointsOverlay()){
             return null;
         }
-
-        Optional<Instant> gameStart = plugin.getNextGameStart();
-
-        if(gameStart.isPresent()){
-            int timeToStart = ((int)ChronoUnit.SECONDS.between(Instant.now(), gameStart.get()));
-            panelComponent.getChildren().add(LineComponent.builder()
-                    .left("Time to start:")
-                    .right(""+timeToStart)
-                    .build());
-        } else{
-            Optional<Instant> despawn = plugin.getLastPortalDespawnTime();
-            int timeSincePortal = despawn.isPresent() ? ((int)(ChronoUnit.SECONDS.between(despawn.get(), Instant.now()))) : 0;
-            panelComponent.getChildren().add(LineComponent.builder()
-                    .left("Time since portal:")
-                    .right(""+timeSincePortal)
-                    .rightColor(plugin.getTimeSincePortalColor(timeSincePortal))
-                    .build());
-        }
-
-
 
         panelComponent.getChildren().add(LineComponent.builder()
                         .left("Reward points:")

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
@@ -18,9 +18,10 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
-import java.awt.Color;
+import java.awt.*;
 import java.time.Instant;
 import java.util.*;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -47,6 +48,12 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 
 	@Inject
 	private GuardiansOfTheRiftHelperPanel panel;
+
+	@Inject
+	private GuardiansOfTheRiftHelperStartTimerOverlay startTimerOverlay;
+
+	@Inject
+	private GuardiansOfTheRiftHelperInactivePortalOverlay inactivePortalOverlay;
 
 	@Inject
 	private Notifier notifier;
@@ -76,6 +83,8 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 	private static final int ELEMENTAL_RUNE_WIDGET_ID = 48889879;
 	private static final int GUARDIAN_COUNT_WIDGET_ID = 48889886;
 	private static final int PORTAL_WIDGET_ID = 48889884;
+
+	private final static int PORTAL_SPRITE_ID = 4368;
 
 	private static final int PORTAL_ID = 43729;
 
@@ -167,6 +176,8 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 	{
 		overlayManager.add(overlay);
 		overlayManager.add(panel);
+		overlayManager.add(startTimerOverlay);
+		overlayManager.add(inactivePortalOverlay);
 		isInMinigame = true;
 		expandCardinal.put("S",  "south");
 		expandCardinal.put("SW", "south west");
@@ -182,6 +193,8 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 	protected void shutDown() {
 		overlayManager.remove(overlay);
 		overlayManager.remove(panel);
+		overlayManager.remove(startTimerOverlay);
+		overlayManager.remove(inactivePortalOverlay);
 		reset();
 	}
 
@@ -474,5 +487,27 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 			return Color.YELLOW;
 		}
 		return Color.GREEN;
+	}
+
+	public int getParentWidgetId() {
+		return PARENT_WIDGET_ID;
+	}
+
+	public int getPortalWidgetId() {
+		return PORTAL_WIDGET_ID;
+	}
+
+	public int getPortalSpriteId() {
+		return PORTAL_SPRITE_ID;
+	}
+
+	public void drawCenteredString(Graphics g, String text, Rectangle rect) {
+		FontMetrics metrics = g.getFontMetrics();
+		int x = rect.x + (rect.width - metrics.stringWidth(text)) / 2;
+		int y = rect.y + ((rect.height - metrics.getHeight()) / 2) + metrics.getAscent();
+		g.setColor(Color.BLACK);
+		g.drawString(text, x + 1, y + 1);
+		g.setColor(Color.WHITE);
+		g.drawString(text, x, y);
 	}
 }

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperStartTimerOverlay.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperStartTimerOverlay.java
@@ -1,0 +1,56 @@
+package com.datbear;
+
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.Overlay;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+public class GuardiansOfTheRiftHelperStartTimerOverlay extends Overlay {
+    private Client client;
+    private GuardiansOfTheRiftHelperPlugin plugin;
+    private GuardiansOfTheRiftHelperConfig config;
+
+    @Inject
+    public GuardiansOfTheRiftHelperStartTimerOverlay(Client client, GuardiansOfTheRiftHelperPlugin plugin, GuardiansOfTheRiftHelperConfig config) {
+        super(plugin);
+        this.client = client;
+        this.plugin = plugin;
+        this.config = config;
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        if ((!plugin.isInMainRegion() && !plugin.isInMinigame()) || !config.showStartTimerOverlay()) {
+            return null;
+        }
+
+        Optional<Instant> gameStart = plugin.getNextGameStart();
+
+        if (gameStart.isPresent()) {
+            int timeToStart = ((int) ChronoUnit.SECONDS.between(Instant.now(), gameStart.get()));
+
+            // fix for showing negative time
+            if (timeToStart < 0) {
+                return null;
+            }
+
+            String mins = String.format("%01d", timeToStart / 60);
+            String secs = String.format("%02d", timeToStart % 60);
+            String text = mins + ":" + secs;
+
+            int x = 68;
+            int y = 23;
+            int width = 32;
+            int height = 24;
+            Rectangle rect = new Rectangle(x, y + height, width, height);
+
+            plugin.drawCenteredString(graphics, text, rect);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Adds a better overlay showing the time since last portal at the same position as the active portal overlay.

Also adds a better overlay showing the start time at the same position as the portal change timer.

Toggle options for both are in the overlay config section.

[Overlay](https://imgur.com/LvekswP)

[Config](https://imgur.com/EH9KYA6)