### PR TITLE
Implement multiple outlining features

### DIFF
--- a/src/main/java/com/datbear/GuardianInfo.java
+++ b/src/main/java/com/datbear/GuardianInfo.java
@@ -11,18 +11,18 @@ import java.util.Optional;
 import java.util.Set;
 
 public class GuardianInfo {
-    public static final GuardianInfo AIR = new GuardianInfo(1, ItemID.AIR_RUNE, 26887,4353, false, CellType.Weak);
-    public static final GuardianInfo MIND = new GuardianInfo(2, ItemID.MIND_RUNE, 26891,4354, true, CellType.Weak);
-    public static final GuardianInfo WATER = new GuardianInfo(5, ItemID.WATER_RUNE, 26888,4355, false, CellType.Medium);
-    public static final GuardianInfo EARTH = new GuardianInfo(9, ItemID.EARTH_RUNE, 26889,4356, false, CellType.Strong);
-    public static final GuardianInfo FIRE = new GuardianInfo(14, ItemID.FIRE_RUNE, 26890,4357, false, CellType.Overcharged);
-    public static final GuardianInfo BODY = new GuardianInfo(20, ItemID.BODY_RUNE, 26895,4358, true, CellType.Weak);
+    public static final GuardianInfo AIR = new GuardianInfo(1, ItemID.AIR_RUNE, 26887, 4353, false, CellType.Weak);
+    public static final GuardianInfo MIND = new GuardianInfo(2, ItemID.MIND_RUNE, 26891, 4354, true, CellType.Weak);
+    public static final GuardianInfo WATER = new GuardianInfo(5, ItemID.WATER_RUNE, 26888, 4355, false, CellType.Medium);
+    public static final GuardianInfo EARTH = new GuardianInfo(9, ItemID.EARTH_RUNE, 26889, 4356, false, CellType.Strong);
+    public static final GuardianInfo FIRE = new GuardianInfo(14, ItemID.FIRE_RUNE, 26890, 4357, false, CellType.Overcharged);
+    public static final GuardianInfo BODY = new GuardianInfo(20, ItemID.BODY_RUNE, 26895, 4358, true, CellType.Weak);
     public static final GuardianInfo COSMIC = new GuardianInfo(27, ItemID.COSMIC_RUNE, 26896, 4359, true, CellType.Medium);
-    public static final GuardianInfo CHAOS = new GuardianInfo(35, ItemID.CHAOS_RUNE, 26892,4360, true, CellType.Medium);
+    public static final GuardianInfo CHAOS = new GuardianInfo(35, ItemID.CHAOS_RUNE, 26892, 4360, true, CellType.Medium);
     public static final GuardianInfo NATURE = new GuardianInfo(44, ItemID.NATURE_RUNE, 26897, 4361, true, CellType.Strong);
-    public static final GuardianInfo LAW = new GuardianInfo(54, ItemID.LAW_RUNE, 26898,4362, true, CellType.Strong);
-    public static final GuardianInfo DEATH = new GuardianInfo(65, ItemID.DEATH_RUNE, 26893,4363, true, CellType.Overcharged);
-    public static final GuardianInfo BLOOD = new GuardianInfo(77, ItemID.BLOOD_RUNE, 26894,4364, true, CellType.Overcharged);
+    public static final GuardianInfo LAW = new GuardianInfo(54, ItemID.LAW_RUNE, 26898, 4362, true, CellType.Strong);
+    public static final GuardianInfo DEATH = new GuardianInfo(65, ItemID.DEATH_RUNE, 26893, 4363, true, CellType.Overcharged);
+    public static final GuardianInfo BLOOD = new GuardianInfo(77, ItemID.BLOOD_RUNE, 26894, 4364, true, CellType.Overcharged);
 
     public static final Set<GuardianInfo> ALL = ImmutableSet.of(AIR, MIND, WATER, EARTH, FIRE, BODY, COSMIC, CHAOS, NATURE, LAW, DEATH, BLOOD);
 
@@ -47,19 +47,22 @@ public class GuardianInfo {
     public BufferedImage getRuneImage(ItemManager itemManager) {
         return itemManager.getImage(runeId);
     }
-    public BufferedImage getTalismanImage(ItemManager itemManager) { return itemManager.getImage(talismanId); }
 
-    public void spawn(){
+    public BufferedImage getTalismanImage(ItemManager itemManager) {
+        return itemManager.getImage(talismanId);
+    }
+
+    public void spawn() {
         spawnTime = Optional.of(Instant.now());
     }
 
-    public void despawn(){
+    public void despawn() {
         spawnTime = Optional.empty();
     }
 
-    public Color getColor(GuardiansOfTheRiftHelperConfig config){
-        if(config.colorGuardiansByTier()){
-            switch(cellType){
+    public Color getColor(GuardiansOfTheRiftHelperConfig config) {
+        if (config.colorGuardiansByTier()) {
+            switch (cellType) {
                 case Weak:
                     return config.weakGuardianColor();
                 case Medium:

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
@@ -3,37 +3,35 @@ package com.datbear;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
-
-import java.awt.*;
 import net.runelite.client.config.ConfigSection;
 
+import java.awt.*;
+
 @ConfigGroup("guardiansOfTheRiftHelper")
-public interface GuardiansOfTheRiftHelperConfig extends Config
-{
-	@ConfigSection(
-		name = "Outlines",
-		description = "All options relating to colored outlines",
-		position =  0,
-		closedByDefault = true
-	)
-	String outlines = "outlines";
+public interface GuardiansOfTheRiftHelperConfig extends Config {
+    @ConfigSection(
+            name = "Outlines",
+            description = "All options relating to colored outlines",
+            position = 0,
+            closedByDefault = true
+    )
+    String outlines = "outlines";
 
-	@ConfigSection(
-		name = "Overlays",
-		description = "All options relating to overlays",
-		position =  1,
-		closedByDefault = true
+    @ConfigSection(
+            name = "Overlays",
+            description = "All options relating to overlays",
+            position = 1,
+            closedByDefault = true
 
-	)
-	String overlays = "overlays";
+    )
+    String overlays = "overlays";
 
     @ConfigItem(
             keyName = "portalSpawn",
             name = "Notify on portal spawn",
             description = "Notifies you when a portal spawns."
     )
-    default boolean notifyPortalSpawn()
-    {
+    default boolean notifyPortalSpawn() {
         return true;
     }
 
@@ -42,8 +40,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
             name = "Mute game help messages",
             description = "Mutes the over head messages of the apprentices giving game advice."
     )
-    default boolean muteApprentices()
-    {
+    default boolean muteApprentices() {
         return true;
     }
 
@@ -51,10 +48,9 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
             keyName = "outlineCellTable",
             name = "Outline cell table",
             description = "Outlines the Cell table when you have no cells remaining.",
-		section = outlines
+            section = outlines
     )
-    default boolean outlineCellTable()
-    {
+    default boolean outlineCellTable() {
         return true;
     }
 
@@ -62,10 +58,9 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
             keyName = "outlineGreatGuardian",
             name = "Outline Great Guardian",
             description = "Outlines the Great Guardian when you have elemental or catalytic essence in your inventory.",
-			section = outlines
+            section = outlines
     )
-    default boolean outlineGreatGuardian()
-    {
+    default boolean outlineGreatGuardian() {
         return true;
     }
 
@@ -75,8 +70,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
             name = "Add cooldown to Quick-Pass",
             description = "Adds a 3 tick delay to the Quick-Pass menu option so you don't enter/leave by spam clicking the gate with Menu Entry Swapper's quick-pass option enabled."
     )
-    default boolean quickPassCooldown()
-    {
+    default boolean quickPassCooldown() {
         return true;
     }
 
@@ -84,10 +78,9 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
             keyName = "elementalGuardianColor",
             name = "Elemental outline",
             description = "Color of the outline on the active elemental guardian.",
-			section = outlines
+            section = outlines
     )
-    default Color elementalGuardianColor()
-    {
+    default Color elementalGuardianColor() {
         return Color.GREEN;
     }
 
@@ -95,33 +88,31 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
             keyName = "catalyticGuardianColor",
             name = "Catalytic outline",
             description = "Color of the outline on the active catalytic guardian.",
-			section = outlines
+            section = outlines
     )
-    default Color catalyticGuardianColor()
-    {
+    default Color catalyticGuardianColor() {
         return Color.RED;
     }
-
 
     @ConfigItem(
             keyName = "outlineGuardiansByTier",
             name = "Color guardians by cell tier",
             description = "Outlines active portal guardians with colors based on their Cell charge tiers instead of Elemental vs Catalytic.",
             position = 2,
-			section = outlines
+            section = outlines
     )
-    default boolean colorGuardiansByTier() { return false; }
-
+    default boolean colorGuardiansByTier() {
+        return false;
+    }
 
     @ConfigItem(
             keyName = "weakGuardianColor",
             name = "Weak outline",
             description = "Color of the outline on an active weak guardian.",
             position = 3,
-			section = outlines
+            section = outlines
     )
-    default Color weakGuardianColor()
-    {
+    default Color weakGuardianColor() {
         return Color.WHITE;
     }
 
@@ -130,10 +121,9 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
             name = "Medium outline",
             description = "Color of the outline on an active medium guardian.",
             position = 4,
-			section = outlines
+            section = outlines
     )
-    default Color mediumGuardianColor()
-    {
+    default Color mediumGuardianColor() {
         return Color.BLUE;
     }
 
@@ -142,10 +132,9 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
             name = "Strong outline",
             description = "Color of the outline on an active strong guardian.",
             position = 5,
-			section = outlines
+            section = outlines
     )
-    default Color strongGuardianColor()
-    {
+    default Color strongGuardianColor() {
         return Color.GREEN;
     }
 
@@ -154,22 +143,64 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
             name = "Overcharged outline",
             description = "Color of the outline on an active overcharged guardian.",
             position = 6,
-			section = outlines
+            section = outlines
     )
-    default Color overchargedGuardianColor()
-    {
+    default Color overchargedGuardianColor() {
         return Color.RED;
+    }
+
+    @ConfigItem(
+            keyName = "talismanOverride",
+            name = "Talisman override",
+            description = "Override active outlined portals with the talisman guardian portal if in inventory.",
+            position = 7,
+            section = outlines
+    )
+    default boolean talismanOverride() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "limitOutlinedGuardians",
+            name = "Limit outlined guardians",
+            description = "Limit the outlined guardians to a single one based on the following selection.",
+            position = 8,
+            section = outlines
+    )
+    default boolean limitOutlinedGuardians() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "limitOutlineTo",
+            name = "Limit outline to",
+            description = "Outline only the active guardian portal with the highest selected option.",
+            position = 9,
+            section = outlines
+    )
+    default LimitOutlineToConfigOptions limitOutlineTo() {
+        return LimitOutlineToConfigOptions.Profit;
+    }
+
+    @ConfigItem(
+            keyName = "onlyOutlineGuardianCustom",
+            name = "Custom outline list",
+            description = "Outline only the highest listed portal guardian.",
+            position = 10,
+            section = outlines
+    )
+    default String onlyOutlineGuardianByCustom() {
+        return "blood rune,death rune,fire rune,nature rune,law rune,cosmic rune,earth rune,chaos rune,water rune,air rune,mind rune,body rune";
     }
 
     @ConfigItem(
             keyName = "startTimerOverlayLocation",
             name = "Start Timer Overlay Location",
             description = "Toggles the start timer overlay location.",
-            position =  7,
+            position = 11,
             section = overlays
     )
-    default TimerOverlayLocation startTimerOverlayLocation()
-    {
+    default TimerOverlayLocation startTimerOverlayLocation() {
         return TimerOverlayLocation.InfoBox;
     }
 
@@ -177,11 +208,10 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
             keyName = "inactivePortalOverlayLocation",
             name = "Inactive Portal Overlay Location",
             description = "Toggles the inactive portal overlay location.",
-            position =  8,
+            position = 12,
             section = overlays
     )
-    default TimerOverlayLocation inactivePortalOverlayLocation()
-    {
+    default TimerOverlayLocation inactivePortalOverlayLocation() {
         return TimerOverlayLocation.InfoBox;
     }
 
@@ -189,47 +219,54 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
             keyName = "showPointsOverlay",
             name = "Show Points Overlay",
             description = "Toggles the points overlay.",
-            position =  9,
+            position = 13,
             section = overlays
     )
-    default boolean showPointsOverlay()
-    {
+    default boolean showPointsOverlay() {
         return true;
     }
 
-	@ConfigItem(
-		keyName = "potentialPoints",
-		name = "Show potential points",
-		description = "Show tallied up points during a game",
-		position =  10,
-		section = overlays
-	)
-	default boolean potentialPoints() { return true; }
+    @ConfigItem(
+            keyName = "potentialPoints",
+            name = "Show potential points",
+            description = "Show tallied up points during a game",
+            position = 14,
+            section = overlays
+    )
+    default boolean potentialPoints() {
+        return true;
+    }
 
-	@ConfigItem(
-		keyName = "highlightPotential",
-		name = "Highlight potential points",
-		description =  "Highlight potential points depending on balance",
-		position =  11,
-		section = overlays
-	)
-	default boolean highlightPotential() { return true; }
+    @ConfigItem(
+            keyName = "highlightPotential",
+            name = "Highlight potential points",
+            description = "Highlight potential points depending on balance",
+            position = 15,
+            section = overlays
+    )
+    default boolean highlightPotential() {
+        return true;
+    }
 
-	@ConfigItem(
-		keyName = "potentialUnbalanceColor",
-		name = "Unbalanced potential color",
-		description =  "Color to highlight potential points when unbalanced",
-		position = 12,
-		section = overlays
-	)
-	default Color potentialUnbalanceColor() { return Color.RED; }
+    @ConfigItem(
+            keyName = "potentialUnbalanceColor",
+            name = "Unbalanced potential color",
+            description = "Color to highlight potential points when unbalanced",
+            position = 16,
+            section = overlays
+    )
+    default Color potentialUnbalanceColor() {
+        return Color.RED;
+    }
 
-	@ConfigItem(
-		keyName = "potentialBalanceColor",
-		name = "Balanced potential color",
-		description =  "Color to highlight potential points when balanced",
-		position =  13,
-		section = overlays
-	)
-	default Color potentialBalanceColor() { return Color.GREEN; }
+    @ConfigItem(
+            keyName = "potentialBalanceColor",
+            name = "Balanced potential color",
+            description = "Color to highlight potential points when balanced",
+            position = 17,
+            section = overlays
+    )
+    default Color potentialBalanceColor() {
+        return Color.GREEN;
+    }
 }

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
@@ -95,21 +95,10 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "talismanOverride",
-            name = "Talisman override",
-            description = "Override active outlined portals with the talisman guardian portal if in inventory.",
-            position = 2,
-            section = outlines
-    )
-    default boolean talismanOverride() {
-        return false;
-    }
-
-    @ConfigItem(
             keyName = "levelOverride",
             name = "Level override",
             description = "Limited the active outlined guardian portals to the ones which you have the sufficient level for.",
-            position = 3,
+            position = 2,
             section = outlines
     )
     default boolean levelOverride() {
@@ -120,7 +109,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "outlineGuardiansByTier",
             name = "Color guardians by cell tier",
             description = "Outlines active portal guardians with colors based on their Cell charge tiers instead of Elemental vs Catalytic.",
-            position = 4,
+            position = 3,
             section = outlines
     )
     default boolean colorGuardiansByTier() {
@@ -131,7 +120,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "weakGuardianColor",
             name = "Weak outline",
             description = "Color of the outline on an active weak guardian.",
-            position = 5,
+            position = 4,
             section = outlines
     )
     default Color weakGuardianColor() {
@@ -142,7 +131,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "mediumGuardianColor",
             name = "Medium outline",
             description = "Color of the outline on an active medium guardian.",
-            position = 6,
+            position = 5,
             section = outlines
     )
     default Color mediumGuardianColor() {
@@ -153,7 +142,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "strongGuardianColor",
             name = "Strong outline",
             description = "Color of the outline on an active strong guardian.",
-            position = 7,
+            position = 6,
             section = outlines
     )
     default Color strongGuardianColor() {
@@ -164,7 +153,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "overchargedGuardianColor",
             name = "Overcharged outline",
             description = "Color of the outline on an active overcharged guardian.",
-            position = 8,
+            position = 7,
             section = outlines
     )
     default Color overchargedGuardianColor() {
@@ -175,7 +164,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "limitOutlineTo",
             name = "Limit outline to",
             description = "Outline only the active guardian portal with the highest selected option.",
-            position = 9,
+            position = 8,
             section = outlines
     )
     default LimitOutlineToConfigOptions limitOutlineTo() {
@@ -186,7 +175,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "onlyOutlineGuardianCustom",
             name = "Custom outline list",
             description = "Outline only the highest listed portal guardian.",
-            position = 10,
+            position = 9,
             section = outlines
     )
     default String onlyOutlineGuardianByCustom() {
@@ -197,7 +186,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "startTimerOverlayLocation",
             name = "Start Timer Overlay Location",
             description = "Toggles the start timer overlay location.",
-            position = 11,
+            position = 10,
             section = overlays
     )
     default TimerOverlayLocation startTimerOverlayLocation() {
@@ -208,7 +197,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "inactivePortalOverlayLocation",
             name = "Inactive Portal Overlay Location",
             description = "Toggles the inactive portal overlay location.",
-            position = 12,
+            position = 11,
             section = overlays
     )
     default TimerOverlayLocation inactivePortalOverlayLocation() {
@@ -219,7 +208,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "showPointsOverlay",
             name = "Show Points Overlay",
             description = "Toggles the points overlay.",
-            position = 13,
+            position = 12,
             section = overlays
     )
     default boolean showPointsOverlay() {
@@ -230,7 +219,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "potentialPoints",
             name = "Show potential points",
             description = "Show tallied up points during a game",
-            position = 14,
+            position = 13,
             section = overlays
     )
     default boolean potentialPoints() {
@@ -241,7 +230,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "highlightPotential",
             name = "Highlight potential points",
             description = "Highlight potential points depending on balance",
-            position = 15,
+            position = 14,
             section = overlays
     )
     default boolean highlightPotential() {
@@ -252,7 +241,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "potentialUnbalanceColor",
             name = "Unbalanced potential color",
             description = "Color to highlight potential points when unbalanced",
-            position = 16,
+            position = 15,
             section = overlays
     )
     default Color potentialUnbalanceColor() {
@@ -263,7 +252,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "potentialBalanceColor",
             name = "Balanced potential color",
             description = "Color to highlight potential points when balanced",
-            position = 17,
+            position = 16,
             section = overlays
     )
     default Color potentialBalanceColor() {

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
@@ -95,10 +95,32 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "talismanOverride",
+            name = "Talisman override",
+            description = "Override active outlined portals with the talisman guardian portal if in inventory.",
+            position = 2,
+            section = outlines
+    )
+    default boolean talismanOverride() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "levelOverride",
+            name = "Level override",
+            description = "Limited the active outlined guardian portals to the ones which you have the sufficient level for.",
+            position = 3,
+            section = outlines
+    )
+    default boolean levelOverride() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "outlineGuardiansByTier",
             name = "Color guardians by cell tier",
             description = "Outlines active portal guardians with colors based on their Cell charge tiers instead of Elemental vs Catalytic.",
-            position = 2,
+            position = 4,
             section = outlines
     )
     default boolean colorGuardiansByTier() {
@@ -109,7 +131,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "weakGuardianColor",
             name = "Weak outline",
             description = "Color of the outline on an active weak guardian.",
-            position = 3,
+            position = 5,
             section = outlines
     )
     default Color weakGuardianColor() {
@@ -120,7 +142,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "mediumGuardianColor",
             name = "Medium outline",
             description = "Color of the outline on an active medium guardian.",
-            position = 4,
+            position = 6,
             section = outlines
     )
     default Color mediumGuardianColor() {
@@ -131,7 +153,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "strongGuardianColor",
             name = "Strong outline",
             description = "Color of the outline on an active strong guardian.",
-            position = 5,
+            position = 7,
             section = outlines
     )
     default Color strongGuardianColor() {
@@ -142,33 +164,11 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             keyName = "overchargedGuardianColor",
             name = "Overcharged outline",
             description = "Color of the outline on an active overcharged guardian.",
-            position = 6,
+            position = 8,
             section = outlines
     )
     default Color overchargedGuardianColor() {
         return Color.RED;
-    }
-
-    @ConfigItem(
-            keyName = "talismanOverride",
-            name = "Talisman override",
-            description = "Override active outlined portals with the talisman guardian portal if in inventory.",
-            position = 7,
-            section = outlines
-    )
-    default boolean talismanOverride() {
-        return false;
-    }
-
-    @ConfigItem(
-            keyName = "limitOutlinedGuardians",
-            name = "Limit outlined guardians",
-            description = "Limit the outlined guardians to a single one based on the following selection.",
-            position = 8,
-            section = outlines
-    )
-    default boolean limitOutlinedGuardians() {
-        return false;
     }
 
     @ConfigItem(
@@ -179,7 +179,7 @@ public interface GuardiansOfTheRiftHelperConfig extends Config {
             section = outlines
     )
     default LimitOutlineToConfigOptions limitOutlineTo() {
-        return LimitOutlineToConfigOptions.Profit;
+        return LimitOutlineToConfigOptions.NO_LIMIT;
     }
 
     @ConfigItem(

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperOverlay.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperOverlay.java
@@ -1,7 +1,7 @@
 package com.datbear;
 
-import net.runelite.api.*;
 import net.runelite.api.Point;
+import net.runelite.api.*;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -15,15 +15,11 @@ import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
-import java.util.Optional;
-import java.util.Set;
+import java.util.List;
+import java.util.*;
 
 public class GuardiansOfTheRiftHelperOverlay extends Overlay {
-    private static final Color GREEN = new Color(0,255,0, 150);
-    private static final Color RED = new Color(255, 0, 0, 150);
-
-    public static final HashMap<Integer, GuardianInfo> GUARDIAN_INFO = new HashMap<Integer, GuardianInfo>(){{
+    public static final HashMap<Integer, GuardianInfo> GUARDIAN_INFO = new HashMap<Integer, GuardianInfo>() {{
         put(43701, GuardianInfo.AIR);
         put(43705, GuardianInfo.MIND);
         put(43702, GuardianInfo.WATER);
@@ -37,27 +33,45 @@ public class GuardiansOfTheRiftHelperOverlay extends Overlay {
         put(43707, GuardianInfo.DEATH);
         put(43708, GuardianInfo.BLOOD);
     }};
+    private static final List<Integer> RAIMENTS_OF_THE_EYE_SET_IDS = new ArrayList<Integer>() {{
+        add(ItemID.HAT_OF_THE_EYE);
+        add(ItemID.HAT_OF_THE_EYE_BLUE);
+        add(ItemID.HAT_OF_THE_EYE_GREEN);
+        add(ItemID.HAT_OF_THE_EYE_RED);
+        add(ItemID.ROBE_BOTTOMS_OF_THE_EYE);
+        add(ItemID.ROBE_BOTTOMS_OF_THE_EYE_BLUE);
+        add(ItemID.ROBE_BOTTOMS_OF_THE_EYE_GREEN);
+        add(ItemID.ROBE_BOTTOMS_OF_THE_EYE_RED);
+        add(ItemID.ROBE_TOP_OF_THE_EYE);
+        add(ItemID.ROBE_TOP_OF_THE_EYE_BLUE);
+        add(ItemID.ROBE_TOP_OF_THE_EYE_GREEN);
+        add(ItemID.ROBE_TOP_OF_THE_EYE_RED);
+        add(ItemID.BOOTS_OF_THE_EYE);
+    }};
+
+    private static final Color GREEN = new Color(0, 255, 0, 150);
+    private static final Color RED = new Color(255, 0, 0, 150);
 
     private static final int GUARDIAN_TICK_COUNT = 33;
     private static final int PORTAL_TICK_COUNT = 43;
-
     private static final int RUNE_IMAGE_OFFSET = 505;
+
+    private final Client client;
+    private final GuardiansOfTheRiftHelperPlugin plugin;
+    private final GuardiansOfTheRiftHelperConfig config;
+    private final RuneLookupTable runeLookupTable;
 
     @Inject
     private ItemManager itemManager;
-
     @Inject
     private ModelOutlineRenderer modelOutlineRenderer;
-
-    private Client client;
-    private GuardiansOfTheRiftHelperPlugin plugin;
-    private GuardiansOfTheRiftHelperConfig config;
 
     @Inject
     public GuardiansOfTheRiftHelperOverlay(Client client, GuardiansOfTheRiftHelperPlugin plugin, GuardiansOfTheRiftHelperConfig config) {
         super();
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ABOVE_SCENE);
+        this.runeLookupTable = new RuneLookupTable();
         this.client = client;
         this.plugin = plugin;
         this.config = config;
@@ -65,7 +79,7 @@ public class GuardiansOfTheRiftHelperOverlay extends Overlay {
 
     @Override
     public Dimension render(Graphics2D graphics) {
-        if(plugin.isInMainRegion()){
+        if (plugin.isInMainRegion()) {
             renderActiveGuardians(graphics);
             highlightGreatGuardian(graphics);
             highlightUnchargedCellTable(graphics);
@@ -75,90 +89,130 @@ public class GuardiansOfTheRiftHelperOverlay extends Overlay {
         return null;
     }
 
-    private void renderPortal(Graphics2D graphics){
-        if(plugin.getPortalSpawnTime().isPresent() && plugin.getPortal() != null){
+    private void renderPortal(Graphics2D graphics) {
+        if (plugin.getPortalSpawnTime().isPresent() && plugin.getPortal() != null) {
             Instant spawnTime = plugin.getPortalSpawnTime().get();
             GameObject portal = plugin.getPortal();
-            long millis = ChronoUnit.MILLIS.between(Instant.now(), spawnTime.plusMillis((long)Math.floor(PORTAL_TICK_COUNT * 600)));
-            String timeRemainingText = ""+(Math.round(millis/100)/10d);
-            Point textLocation =  Perspective.getCanvasTextLocation(client, graphics, portal.getLocalLocation(), timeRemainingText, 100);
+            long millis = ChronoUnit.MILLIS.between(Instant.now(), spawnTime.plusMillis((long) Math.floor(PORTAL_TICK_COUNT * 600)));
+            String timeRemainingText = "" + (Math.round(millis / 100) / 10d);
+            Point textLocation = Perspective.getCanvasTextLocation(client, graphics, portal.getLocalLocation(), timeRemainingText, 100);
             OverlayUtil.renderTextLocation(graphics, textLocation, timeRemainingText, Color.WHITE);
         }
     }
 
-    private void highlightEssencePiles(Graphics2D graphics){
-        if(plugin.isShouldMakeGuardian()) {
+    private void highlightEssencePiles(Graphics2D graphics) {
+        if (plugin.isShouldMakeGuardian()) {
             GameObject elementalEss = plugin.getElementalEssencePile();
             GameObject catalyticEss = plugin.getCatalyticEssencePile();
-            if(elementalEss != null) {
+            if (elementalEss != null) {
                 modelOutlineRenderer.drawOutline(elementalEss, 2, GREEN, 2);
             }
-            if(catalyticEss != null) {
+            if (catalyticEss != null) {
                 modelOutlineRenderer.drawOutline(catalyticEss, 2, GREEN, 2);
             }
         }
     }
 
-    private void renderActiveGuardians(Graphics2D graphics){
-        if(!plugin.isInMainRegion()) return;
+    private Comparator<GameObject> getLimitOutlineComparator() {
+        Comparator<GameObject> comparator;
+        switch (this.config.limitOutlineTo()) {
+            case Catalytic:
+                comparator = Comparator.comparing((GameObject guardian) -> !GUARDIAN_INFO.get(guardian.getId()).isCatalytic);
+                break;
+            case Elemental:
+                comparator = Comparator.comparing((GameObject guardian) -> GUARDIAN_INFO.get(guardian.getId()).isCatalytic);
+                break;
+            case Level:
+                comparator = Comparator.comparing((GameObject guardian) -> GUARDIAN_INFO.get(guardian.getId()).levelRequired).reversed();
+                break;
+            case Tier:
+                comparator = Comparator.comparing((GameObject guardian) -> GUARDIAN_INFO.get(guardian.getId()).cellType).reversed();
+                break;
+            case Profit:
+                comparator = Comparator.comparing((GameObject guardian) -> calculateProfitPerFragment(GUARDIAN_INFO.get(guardian.getId()).runeId, this.client.getBoostedSkillLevel(Skill.RUNECRAFT), this.client.getItemContainer(InventoryID.EQUIPMENT))).reversed();
+                break;
+            case Custom:
+                List<String> customList = Arrays.asList(config.onlyOutlineGuardianByCustom().toUpperCase().split(","));
+                comparator = Comparator.comparing(guardian -> customList.indexOf(itemManager.getItemComposition(GUARDIAN_INFO.get(guardian.getId()).runeId).getMembersName().toUpperCase()));
+                break;
+            default:
+                comparator = Comparator.comparing(GameObject::getId);
+                break;
+        }
+        return comparator;
+    }
+
+    private double calculateProfitPerFragment(int itemId, int playerLevel, ItemContainer itemContainer) {
+        double amountOfSetWearing = itemContainer == null ? 0 : Arrays.stream(itemContainer.getItems()).map(Item::getId).filter(id -> RAIMENTS_OF_THE_EYE_SET_IDS.stream().anyMatch(bonusId -> bonusId.equals(id))).count();
+        double setBonus = 1 + (amountOfSetWearing * .1 + (amountOfSetWearing == 4 ? .2 : 0));
+
+        return this.itemManager.getItemPrice(itemId) * (runeLookupTable.getHighestMultiplier(itemId, playerLevel) * setBonus);
+    }
+
+    private void renderActiveGuardians(Graphics2D graphics) {
+        if (!plugin.isInMainRegion()) return;
 
         Set<GameObject> activeGuardians = plugin.getActiveGuardians();
         Set<GameObject> guardians = plugin.getGuardians();
         Set<Integer> inventoryTalismans = plugin.getInventoryTalismans();
 
-        for(GameObject guardian : activeGuardians) {
-            if(guardian == null) continue;
-            Shape hull = guardian.getConvexHull();
-            if(hull == null) continue;
-
-            GuardianInfo info = GUARDIAN_INFO.get(guardian.getId());
-            Color color = info.getColor(config);
-            graphics.setColor(color);
-
-            modelOutlineRenderer.drawOutline(guardian, 2, color, 2);
-
-            BufferedImage img = info.getRuneImage(itemManager);
-            OverlayUtil.renderImageLocation(client, graphics, guardian.getLocalLocation(), img, RUNE_IMAGE_OFFSET);
-            if(info.spawnTime.isPresent()) {
-                Point imgLocation = Perspective.getCanvasImageLocation(client, guardian.getLocalLocation(), img, RUNE_IMAGE_OFFSET);
-                long millis = ChronoUnit.MILLIS.between(Instant.now(), info.spawnTime.get().plusMillis((long)Math.floor(GUARDIAN_TICK_COUNT * 600)));
-                String timeRemainingText = ""+(Math.round(millis/100)/10d);
-                Rectangle2D strBounds = graphics.getFontMetrics().getStringBounds(timeRemainingText, graphics);
-                Point textLocation =  Perspective.getCanvasTextLocation(client, graphics, guardian.getLocalLocation(), timeRemainingText, RUNE_IMAGE_OFFSET+60);
-                textLocation = new Point((int)(imgLocation.getX() + img.getWidth()/2d - strBounds.getWidth()/2d), textLocation.getY());
-                OverlayUtil.renderTextLocation(graphics, textLocation, timeRemainingText, Color.WHITE);
-            }
-        }
-
-        for(int talisman : inventoryTalismans){
+        boolean isTalismanGuardianPortalFound = false;
+        for (int talisman : inventoryTalismans) {
             Optional<GameObject> talismanGuardian = guardians.stream().filter(x -> GUARDIAN_INFO.get(x.getId()).talismanId == talisman).findFirst();
 
-            if(talismanGuardian.isPresent() && activeGuardians.stream().noneMatch(x -> x.getId() == talismanGuardian.get().getId())) {
+            isTalismanGuardianPortalFound = talismanGuardian.isPresent() && activeGuardians.stream().noneMatch(x -> x.getId() == talismanGuardian.get().getId());
+            if (isTalismanGuardianPortalFound) {
                 GuardianInfo talismanGuardianInfo = GUARDIAN_INFO.get(talismanGuardian.get().getId());
                 modelOutlineRenderer.drawOutline(talismanGuardian.get(), 2, talismanGuardianInfo.getColor(config), 2);
                 OverlayUtil.renderImageLocation(client, graphics, talismanGuardian.get().getLocalLocation(), talismanGuardianInfo.getTalismanImage(itemManager), RUNE_IMAGE_OFFSET);
             }
         }
+
+        if (!config.talismanOverride() || !isTalismanGuardianPortalFound) {
+            activeGuardians.stream()
+                    .filter(guardian -> guardian != null && guardian.getConvexHull() != null)
+                    .sorted(getLimitOutlineComparator())
+                    .limit(this.config.limitOutlinedGuardians() ? 1 : 2)
+                    .forEach(guardian -> {
+                        GuardianInfo guardianInfo = GUARDIAN_INFO.get(guardian.getId());
+                        Color color = guardianInfo.getColor(config);
+                        graphics.setColor(color);
+
+                        modelOutlineRenderer.drawOutline(guardian, 2, color, 2);
+
+                        BufferedImage img = guardianInfo.getRuneImage(itemManager);
+                        OverlayUtil.renderImageLocation(client, graphics, guardian.getLocalLocation(), img, RUNE_IMAGE_OFFSET);
+                        if (guardianInfo.spawnTime.isPresent()) {
+                            Point imgLocation = Perspective.getCanvasImageLocation(client, guardian.getLocalLocation(), img, RUNE_IMAGE_OFFSET);
+                            long millis = ChronoUnit.MILLIS.between(Instant.now(), guardianInfo.spawnTime.get().plusMillis((long) Math.floor(GUARDIAN_TICK_COUNT * 600)));
+                            String timeRemainingText = "" + (Math.round(millis / 100) / 10d);
+                            Rectangle2D strBounds = graphics.getFontMetrics().getStringBounds(timeRemainingText, graphics);
+                            Point textLocation = Perspective.getCanvasTextLocation(client, graphics, guardian.getLocalLocation(), timeRemainingText, RUNE_IMAGE_OFFSET + 60);
+                            textLocation = new Point((int) (imgLocation.getX() + img.getWidth() / 2d - strBounds.getWidth() / 2d), textLocation.getY());
+                            OverlayUtil.renderTextLocation(graphics, textLocation, timeRemainingText, Color.WHITE);
+                        }
+                    });
+        }
     }
 
     private void highlightGreatGuardian(Graphics2D graphics) {
-        if(!config.outlineGreatGuardian()){
+        if (!config.outlineGreatGuardian()) {
             return;
         }
 
         NPC greatGuardian = plugin.getGreatGuardian();
-        if(plugin.isOutlineGreatGuardian() && greatGuardian != null){
+        if (plugin.isOutlineGreatGuardian() && greatGuardian != null) {
             modelOutlineRenderer.drawOutline(greatGuardian, 2, Color.GREEN, 2);
         }
     }
 
     private void highlightUnchargedCellTable(Graphics2D graphics) {
-        if(!config.outlineCellTable()){
+        if (!config.outlineCellTable()) {
             return;
         }
 
         GameObject table = plugin.getUnchargedCellTable();
-        if(plugin.isOutlineUnchargedCellTable() && table != null){
+        if (plugin.isOutlineUnchargedCellTable() && table != null) {
             modelOutlineRenderer.drawOutline(table, 2, GREEN, 2);
         }
     }

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperOverlay.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperOverlay.java
@@ -116,27 +116,27 @@ public class GuardiansOfTheRiftHelperOverlay extends Overlay {
     private Comparator<GameObject> getLimitOutlineComparator() {
         Comparator<GameObject> comparator;
         switch (this.config.limitOutlineTo()) {
-            case Catalytic:
+            case CATALYTIC:
                 comparator = Comparator.comparing((GameObject guardian) -> !GUARDIAN_INFO.get(guardian.getId()).isCatalytic);
                 break;
-            case Elemental:
+            case ELEMENTAL:
                 comparator = Comparator.comparing((GameObject guardian) -> GUARDIAN_INFO.get(guardian.getId()).isCatalytic);
                 break;
-            case Level:
+            case HIGHEST_LEVEL:
                 comparator = Comparator.comparing((GameObject guardian) -> GUARDIAN_INFO.get(guardian.getId()).levelRequired).reversed();
                 break;
-            case Tier:
-                comparator = Comparator.comparing((GameObject guardian) -> GUARDIAN_INFO.get(guardian.getId()).cellType).reversed();
+            case HIGHEST_TIER:
+                comparator = Comparator.comparing((GameObject guardian) -> GUARDIAN_INFO.get(guardian.getId()).cellType).thenComparing((GameObject guardian) -> calculateProfitPerFragment(GUARDIAN_INFO.get(guardian.getId()).runeId, this.client.getBoostedSkillLevel(Skill.RUNECRAFT), this.client.getItemContainer(InventoryID.EQUIPMENT))).reversed();
                 break;
-            case Profit:
+            case HIGHEST_PROFIT:
                 comparator = Comparator.comparing((GameObject guardian) -> calculateProfitPerFragment(GUARDIAN_INFO.get(guardian.getId()).runeId, this.client.getBoostedSkillLevel(Skill.RUNECRAFT), this.client.getItemContainer(InventoryID.EQUIPMENT))).reversed();
                 break;
-            case Custom:
+            case CUSTOM:
                 List<String> customList = Arrays.asList(config.onlyOutlineGuardianByCustom().toUpperCase().split(","));
                 comparator = Comparator.comparing(guardian -> customList.indexOf(itemManager.getItemComposition(GUARDIAN_INFO.get(guardian.getId()).runeId).getMembersName().toUpperCase()));
                 break;
             default:
-                comparator = Comparator.comparing(GameObject::getId);
+                comparator = Comparator.comparing(GameObject::getId).reversed();
                 break;
         }
         return comparator;
@@ -170,9 +170,9 @@ public class GuardiansOfTheRiftHelperOverlay extends Overlay {
 
         if (!config.talismanOverride() || !isTalismanGuardianPortalFound) {
             activeGuardians.stream()
-                    .filter(guardian -> guardian != null && guardian.getConvexHull() != null)
+                    .filter(guardian -> guardian != null && guardian.getConvexHull() != null && (!this.config.levelOverride() || GUARDIAN_INFO.get(guardian.getId()).levelRequired <= this.client.getBoostedSkillLevel(Skill.RUNECRAFT)))
                     .sorted(getLimitOutlineComparator())
-                    .limit(this.config.limitOutlinedGuardians() ? 1 : 2)
+                    .limit(this.config.limitOutlineTo() == LimitOutlineToConfigOptions.NO_LIMIT ? 2 : 1)
                     .forEach(guardian -> {
                         GuardianInfo guardianInfo = GUARDIAN_INFO.get(guardian.getId());
                         Color color = guardianInfo.getColor(config);

--- a/src/main/java/com/datbear/LimitOutlineToConfigOptions.java
+++ b/src/main/java/com/datbear/LimitOutlineToConfigOptions.java
@@ -1,10 +1,11 @@
 package com.datbear;
 
 public enum LimitOutlineToConfigOptions {
-    Catalytic,
-    Elemental,
-    Level,
-    Tier,
-    Profit,
-    Custom
+    NO_LIMIT,
+    CATALYTIC,
+    ELEMENTAL,
+    HIGHEST_LEVEL,
+    HIGHEST_TIER,
+    HIGHEST_PROFIT,
+    CUSTOM;
 }

--- a/src/main/java/com/datbear/LimitOutlineToConfigOptions.java
+++ b/src/main/java/com/datbear/LimitOutlineToConfigOptions.java
@@ -1,0 +1,10 @@
+package com.datbear;
+
+public enum LimitOutlineToConfigOptions {
+    Catalytic,
+    Elemental,
+    Level,
+    Tier,
+    Profit,
+    Custom
+}

--- a/src/main/java/com/datbear/RuneLookupTable.java
+++ b/src/main/java/com/datbear/RuneLookupTable.java
@@ -1,0 +1,108 @@
+package com.datbear;
+
+import net.runelite.api.ItemID;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RuneLookupTable {
+    private final Map<Integer, List<LevelMultiplier>> lookupTable;
+
+    public RuneLookupTable() {
+        this.lookupTable = new HashMap<Integer, List<LevelMultiplier>>() {{
+            put(ItemID.AIR_RUNE, new ArrayList<LevelMultiplier>() {{
+                add(new LevelMultiplier(11, 2));
+                add(new LevelMultiplier(22, 3));
+                add(new LevelMultiplier(33, 4));
+                add(new LevelMultiplier(44, 5));
+                add(new LevelMultiplier(55, 6));
+                add(new LevelMultiplier(66, 7));
+                add(new LevelMultiplier(77, 8));
+                add(new LevelMultiplier(88, 9));
+                add(new LevelMultiplier(99, 10));
+            }});
+            put(ItemID.MIND_RUNE, new ArrayList<LevelMultiplier>() {{
+                add(new LevelMultiplier(14, 2));
+                add(new LevelMultiplier(28, 3));
+                add(new LevelMultiplier(42, 4));
+                add(new LevelMultiplier(56, 5));
+                add(new LevelMultiplier(70, 6));
+                add(new LevelMultiplier(84, 7));
+                add(new LevelMultiplier(98, 8));
+            }});
+            put(ItemID.WATER_RUNE, new ArrayList<LevelMultiplier>() {{
+                add(new LevelMultiplier(19, 2));
+                add(new LevelMultiplier(38, 3));
+                add(new LevelMultiplier(57, 4));
+                add(new LevelMultiplier(76, 5));
+                add(new LevelMultiplier(95, 6));
+            }});
+            put(ItemID.EARTH_RUNE, new ArrayList<LevelMultiplier>() {{
+                add(new LevelMultiplier(26, 2));
+                add(new LevelMultiplier(52, 3));
+                add(new LevelMultiplier(78, 4));
+                add(new LevelMultiplier(104, 5));
+            }});
+            put(ItemID.FIRE_RUNE, new ArrayList<LevelMultiplier>() {{
+                add(new LevelMultiplier(35, 2));
+                add(new LevelMultiplier(70, 3));
+            }});
+            put(ItemID.BODY_RUNE, new ArrayList<LevelMultiplier>() {{
+                add(new LevelMultiplier(46, 2));
+                add(new LevelMultiplier(92, 3));
+            }});
+            put(ItemID.COSMIC_RUNE, new ArrayList<LevelMultiplier>() {{
+                add(new LevelMultiplier(59, 2));
+            }});
+            put(ItemID.CHAOS_RUNE, new ArrayList<LevelMultiplier>() {{
+                add(new LevelMultiplier(74, 2));
+            }});
+            put(ItemID.NATURE_RUNE, new ArrayList<LevelMultiplier>() {{
+                add(new LevelMultiplier(91, 2));
+            }});
+            put(ItemID.LAW_RUNE, new ArrayList<LevelMultiplier>() {{
+                add(new LevelMultiplier(95, 2));
+            }});
+            put(ItemID.DEATH_RUNE, new ArrayList<LevelMultiplier>() {{
+                add(new LevelMultiplier(99, 2));
+            }});
+        }};
+    }
+
+    public int getHighestMultiplier(int runeId, int level) {
+        List<LevelMultiplier> runeMultipliers = lookupTable.get(runeId);
+        if (runeMultipliers == null) {
+            // Rune ID not found in the lookup table
+            return 1;
+        }
+
+        int highestMultiplier = 1;
+        for (LevelMultiplier levelMultiplier : runeMultipliers) {
+            if (levelMultiplier.getLevel() <= level && levelMultiplier.getMultiplier() > highestMultiplier) {
+                highestMultiplier = levelMultiplier.getMultiplier();
+            }
+        }
+
+        return highestMultiplier;
+    }
+
+    private static class LevelMultiplier {
+        private final int level;
+        private final int multiplier;
+
+        public LevelMultiplier(int level, int multiplier) {
+            this.level = level;
+            this.multiplier = multiplier;
+        }
+
+        public int getLevel() {
+            return level;
+        }
+
+        public int getMultiplier() {
+            return multiplier;
+        }
+    }
+}


### PR DESCRIPTION
- Override active guardian portals outline by the talisman portal if in inventory.
- Override active guardian portals outline to only outline active portal which you have sufficient level for.
- Limit the active guardian portals outline to a single one based on the following selection:
  - catalytic only,
  - elemental only,
  - highest level only,
  - highest tier only,
  - highest profit only,
  - based on a custom list (highest portal in the list will be outlined);