### PR TITLE
fix(overlay): Canvas returned null for text location causing a null

### DIFF
--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperOverlay.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperOverlay.java
@@ -119,15 +119,17 @@ public class GuardiansOfTheRiftHelperOverlay extends Overlay {
 
             BufferedImage img = info.getRuneImage(itemManager);
             OverlayUtil.renderImageLocation(client, graphics, guardian.getLocalLocation(), img, RUNE_IMAGE_OFFSET);
-            if(info.spawnTime.isPresent()) {
-                Point imgLocation = Perspective.getCanvasImageLocation(client, guardian.getLocalLocation(), img, RUNE_IMAGE_OFFSET);
-                long millis = ChronoUnit.MILLIS.between(Instant.now(), info.spawnTime.get().plusMillis((long)Math.floor(GUARDIAN_TICK_COUNT * 600)));
-                String timeRemainingText = ""+(Math.round(millis/100)/10d);
-                Rectangle2D strBounds = graphics.getFontMetrics().getStringBounds(timeRemainingText, graphics);
-                Point textLocation =  Perspective.getCanvasTextLocation(client, graphics, guardian.getLocalLocation(), timeRemainingText, RUNE_IMAGE_OFFSET+60);
-                textLocation = new Point((int)(imgLocation.getX() + img.getWidth()/2d - strBounds.getWidth()/2d), textLocation.getY());
-                OverlayUtil.renderTextLocation(graphics, textLocation, timeRemainingText, Color.WHITE);
-            }
+            if(!info.spawnTime.isPresent()) continue;
+
+            Point imgLocation = Perspective.getCanvasImageLocation(client, guardian.getLocalLocation(), img, RUNE_IMAGE_OFFSET);
+            long millis = ChronoUnit.MILLIS.between(Instant.now(), info.spawnTime.get().plusMillis((long)Math.floor(GUARDIAN_TICK_COUNT * 600)));
+            String timeRemainingText = ""+(Math.round(millis/100)/10d);
+            Rectangle2D strBounds = graphics.getFontMetrics().getStringBounds(timeRemainingText, graphics);
+            Point textLocation =  Perspective.getCanvasTextLocation(client, graphics, guardian.getLocalLocation(), timeRemainingText, RUNE_IMAGE_OFFSET+60);
+            if (textLocation == null) continue;
+
+            textLocation = new Point((int)(imgLocation.getX() + img.getWidth()/2d - strBounds.getWidth()/2d), textLocation.getY());
+            OverlayUtil.renderTextLocation(graphics, textLocation, timeRemainingText, Color.WHITE);
         }
 
         for(int talisman : inventoryTalismans){


### PR DESCRIPTION
**issue:**

Runelite was crashing very often while playing Guardians of the rift.
The client, of my other account, wasn't having crashes.

After looking in the Runelite crash logs (in `~/.runelite/logs`) I saw that it was crashing in `renderActiveGuardians`.
As it is a production build it didn't state the line number.

So I cloned the plugin and lazily added a try/catch in the method.
After a few seconds the debugger hit, giving me a null reference exception on line 128.

**Solution:**
This is strange as Runelite adds a try/catch around the rendering of the overlay.
However, Java is not my primary programming language.
After adding a null check I haven't had any crash ever since.
I've been doing quite a few Guardian of the rift games without any issues.


**Speculation**:
This may have something to do with this specific exception not being catched?
Maybe because of Linux or Arch linux?
Something else?

As this is a null reference it was an issue anyway.

