### PR TITLE
Point balance helper

### DIFF
--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperConfig.java
@@ -70,6 +70,14 @@ public interface GuardiansOfTheRiftHelperConfig extends Config
         return true;
     }
 
+    @ConfigItem(
+            keyName = "pointBalanceHelper",
+            name = "Balance Helper",
+            description = "Highlights the guardian needed to keep points balanced or highest tier",
+            section = outlines
+    )
+    default boolean pointBalanceHelper() { return false; }
+
 
     @ConfigItem(
             keyName = "quickPassCooldown",

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperOverlay.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperOverlay.java
@@ -108,6 +108,9 @@ public class GuardiansOfTheRiftHelperOverlay extends Overlay {
             GuardianInfo info = GUARDIAN_INFO.get(guardian.getId());
 
             if (info.cellType.compareTo(best) > 0 && info.levelRequired < client.getBoostedSkillLevel(Skill.RUNECRAFT)) {
+                if (info.cellType == CellType.Overcharged) {
+                    return CellType.Overcharged;
+                }
                 best = info.cellType;
             }
         }

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperOverlay.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperOverlay.java
@@ -99,6 +99,33 @@ public class GuardiansOfTheRiftHelperOverlay extends Overlay {
         }
     }
 
+    private CellType bestCell(final Set<GameObject> activeGuardians) {
+        CellType best = CellType.Weak;
+        for (final GameObject guardian : activeGuardians) {
+            if(guardian == null) continue;
+            Shape hull = guardian.getConvexHull();
+            if(hull == null) continue;
+            GuardianInfo info = GUARDIAN_INFO.get(guardian.getId());
+
+            if (info.cellType.compareTo(best) > 0 && info.levelRequired < client.getBoostedSkillLevel(Skill.RUNECRAFT)) {
+                best = info.cellType;
+            }
+        }
+        return best;
+    }
+
+    private PointBalance currentBalance() {
+        PointBalance val = PointBalance.BALANCED;
+        final int potElementalPoints = plugin.potentialPointsElemental();
+        final int potCatalyticPoints = plugin.potentialPointsCatalytic();
+        if (potElementalPoints > potCatalyticPoints) {
+            val = PointBalance.NEED_CATALYTIC;
+        } else if (potCatalyticPoints > potElementalPoints) {
+            val = PointBalance.NEED_ELEMENTAL;
+        }
+        return val;
+    }
+
     private void renderActiveGuardians(Graphics2D graphics){
         if(!plugin.isInMainRegion()) return;
 
@@ -106,12 +133,36 @@ public class GuardiansOfTheRiftHelperOverlay extends Overlay {
         Set<GameObject> guardians = plugin.getGuardians();
         Set<Integer> inventoryTalismans = plugin.getInventoryTalismans();
 
+        PointBalance balance = PointBalance.BALANCED;
+        CellType bestCell = null;
+
+        if (config.pointBalanceHelper()) {
+            balance = currentBalance();
+        }
+
+
         for(GameObject guardian : activeGuardians) {
             if(guardian == null) continue;
             Shape hull = guardian.getConvexHull();
             if(hull == null) continue;
 
             GuardianInfo info = GUARDIAN_INFO.get(guardian.getId());
+
+            if (config.pointBalanceHelper()) {
+                if (!info.isCatalytic && balance == PointBalance.NEED_CATALYTIC) {
+                    continue;
+                } else if (info.isCatalytic && balance == PointBalance.NEED_ELEMENTAL) {
+                    continue;
+                } else if (balance == PointBalance.BALANCED) {
+                    if (bestCell == null) {
+                        bestCell = bestCell(activeGuardians);
+                    }
+                    if (info.cellType != bestCell) {
+                        continue;
+                    }
+                }
+            }
+
             Color color = info.getColor(config);
             graphics.setColor(color);
 

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPanel.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPanel.java
@@ -30,13 +30,6 @@ public class GuardiansOfTheRiftHelperPanel extends OverlayPanel {
         getMenuEntries().add(new OverlayMenuEntry(RUNELITE_OVERLAY_CONFIG, OPTION_CONFIGURE, "Guardians of the Rift Helper Overlay"));
     }
 
-	private int potentialPoints(int savedPoints, int currentPoints)
-	{
-		if (currentPoints == 0){
-			return savedPoints;
-		}
-		return savedPoints += currentPoints / 100;
-	}
 
     @Override
     public Dimension render(Graphics2D graphics)
@@ -73,8 +66,8 @@ public class GuardiansOfTheRiftHelperPanel extends OverlayPanel {
 
 		if (config.potentialPoints())
 		{
-			final int potElementalPoints = potentialPoints(plugin.getElementalRewardPoints(), plugin.getCurrentElementalRewardPoints());
-			final int potCatalyticPoints = potentialPoints(plugin.getCatalyticRewardPoints(), plugin.getCurrentCatalyticRewardPoints());
+			final int potElementalPoints = plugin.potentialPointsElemental();
+			final int potCatalyticPoints = plugin.potentialPointsCatalytic();
 			final int elementalRemain = plugin.getCurrentElementalRewardPoints() % 100;
 			final int catalyticRemain = plugin.getCurrentCatalyticRewardPoints() % 100;
 			final String potPoints = String.format("%d.%02d/%d.%02d", potElementalPoints, elementalRemain, potCatalyticPoints, catalyticRemain);

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
@@ -511,4 +511,20 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin
 		g.setColor(Color.WHITE);
 		g.drawString(text, x, y);
 	}
+
+	public int potentialPointsElemental() {
+		return potentialPoints(getElementalRewardPoints(), getCurrentElementalRewardPoints());
+	}
+
+	public int potentialPointsCatalytic() {
+		return potentialPoints(getCatalyticRewardPoints(), getCurrentCatalyticRewardPoints());
+	}
+
+	private int potentialPoints(int savedPoints, int currentPoints)
+	{
+		if (currentPoints == 0){
+			return savedPoints;
+		}
+		return savedPoints += currentPoints / 100;
+	}
 }

--- a/src/main/java/com/datbear/PointBalance.java
+++ b/src/main/java/com/datbear/PointBalance.java
@@ -1,0 +1,7 @@
+package com.datbear;
+
+public enum PointBalance {
+    BALANCED,
+    NEED_ELEMENTAL,
+    NEED_CATALYTIC
+}


### PR DESCRIPTION
Adds a config option which only highlights the guardian required to balance points.
If points are balanced will instead only highlight the strongest cell guardian the player has required level for.