### PR TITLE
added check to prevent portal notification is player is already in the huge guardian remains section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 nbactions.xml
 nb-configuration.xml
 nbproject/
+.vscode/

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
@@ -78,6 +78,10 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin {
     private static final int CHISEL_ID = 1755;
     private static final int OVERCHARGED_CELL_ID = 26886;
 
+    private static final int HUGE_GUARDRIAN_REMAINS_AREA_LEFT_BOUNDARY = 3587;
+    private static final int HUGE_GUARDRIAN_REMAINS_AREA_RIGHT_BOUNDARY = 3594;
+    private static final int HUGE_GUARDRIAN_REMAINS_AREA_TOP_BOUNDARY = 9516;
+    private static final int HUGE_GUARDRIAN_REMAINS_AREA_BOTTOM_BOUNDARY = 9496;
 
     private static final int DEPOSIT_POOL_ID = 43696;
 
@@ -206,6 +210,19 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin {
         return Arrays.stream(currentMapRegions).anyMatch(x -> x == MINIGAME_MAIN_REGION);
     }
 
+    private boolean shouldNotifyThatPortalSpawned() {
+        return config.notifyPortalSpawn().isEnabled() && !playerIsInHugeGuardianRemainsArea();
+    }
+
+    private boolean playerIsInHugeGuardianRemainsArea() {
+        int playerX = client.getLocalPlayer().getWorldLocation().getX();
+        int playerY = client.getLocalPlayer().getWorldLocation().getY();
+        return playerX > HUGE_GUARDRIAN_REMAINS_AREA_LEFT_BOUNDARY &&
+                playerX < HUGE_GUARDRIAN_REMAINS_AREA_RIGHT_BOUNDARY &&
+                playerY < HUGE_GUARDRIAN_REMAINS_AREA_TOP_BOUNDARY &&
+                playerY > HUGE_GUARDRIAN_REMAINS_AREA_BOTTOM_BOUNDARY;
+    }
+
     @Override
     protected void startUp() {
         CELL_TILE_IDS.add(CellTileInfo.WEAK.groundObjectId);
@@ -304,7 +321,7 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin {
                 if (isFirstPortal) {
                     isFirstPortal = false;
                 }
-                if (config.notifyPortalSpawn().isEnabled()) {
+                if (shouldNotifyThatPortalSpawned()) {
                     String compass = portalTextWidget.getText().split(" ")[0];
                     String full = expandCardinal.getOrDefault(compass, "unknown");
                     notifier.notify(config.notifyPortalSpawn(), "A portal has spawned in the " + full + ".");
@@ -393,7 +410,7 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin {
 
         if (gameObject.getId() == PORTAL_ID) {
             portal = gameObject;
-            if (config.notifyPortalSpawn().isEnabled()) {
+            if (shouldNotifyThatPortalSpawned()) {
                 // The hint arrow is cleared under the following circumstances:
                 // 1. Player enters the portal
                 // 2. Plugin is "reset()"

--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
@@ -78,10 +78,10 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin {
     private static final int CHISEL_ID = 1755;
     private static final int OVERCHARGED_CELL_ID = 26886;
 
-    private static final int HUGE_GUARDRIAN_REMAINS_AREA_LEFT_BOUNDARY = 3587;
-    private static final int HUGE_GUARDRIAN_REMAINS_AREA_RIGHT_BOUNDARY = 3594;
-    private static final int HUGE_GUARDRIAN_REMAINS_AREA_TOP_BOUNDARY = 9516;
-    private static final int HUGE_GUARDRIAN_REMAINS_AREA_BOTTOM_BOUNDARY = 9496;
+    private static final int HUGE_GUARDRIAN_REMAINS_AREA_WEST_BOUNDARY = 3587;
+    private static final int HUGE_GUARDRIAN_REMAINS_AREA_EAST_BOUNDARY = 3594;
+    private static final int HUGE_GUARDRIAN_REMAINS_AREA_NORTH_BOUNDARY = 9516;
+    private static final int HUGE_GUARDRIAN_REMAINS_AREA_SOUTH_BOUNDARY = 9496;
 
     private static final int DEPOSIT_POOL_ID = 43696;
 
@@ -217,10 +217,10 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin {
     private boolean playerIsInHugeGuardianRemainsArea() {
         int playerX = client.getLocalPlayer().getWorldLocation().getX();
         int playerY = client.getLocalPlayer().getWorldLocation().getY();
-        return playerX > HUGE_GUARDRIAN_REMAINS_AREA_LEFT_BOUNDARY &&
-                playerX < HUGE_GUARDRIAN_REMAINS_AREA_RIGHT_BOUNDARY &&
-                playerY < HUGE_GUARDRIAN_REMAINS_AREA_TOP_BOUNDARY &&
-                playerY > HUGE_GUARDRIAN_REMAINS_AREA_BOTTOM_BOUNDARY;
+        return playerX > HUGE_GUARDRIAN_REMAINS_AREA_WEST_BOUNDARY &&
+                playerX < HUGE_GUARDRIAN_REMAINS_AREA_EAST_BOUNDARY &&
+                playerY < HUGE_GUARDRIAN_REMAINS_AREA_NORTH_BOUNDARY &&
+                playerY > HUGE_GUARDRIAN_REMAINS_AREA_SOUTH_BOUNDARY;
     }
 
     @Override


### PR DESCRIPTION
There is no value in notifying a player that a new portal has spawned if they're already in that area. This PR aims to fix this by adding a check to the player's current location whenever a portal spawns. If they are already in the location, we do not notify them of the new spawn. In this way, we reduce incoming redundant notifications.

closes DatBear/Guardians-of-the-Rift-Helper#84

Note: the right boundary in the screenshots is 1 tile off to the left. I adjusted this in the code which is why there is a diff of 1.
<img width="741" alt="Screenshot 2025-02-05 at 9 01 13 AM" src="https://github.com/user-attachments/assets/544822a5-ef04-4564-b461-02c8e051f8d7" />
<img width="783" alt="Screenshot 2025-02-05 at 9 01 46 AM" src="https://github.com/user-attachments/assets/b5f45df6-8864-458a-b891-e1e1ffa6ce12" />
<img width="1035" alt="Screenshot 2025-02-05 at 9 02 02 AM" src="https://github.com/user-attachments/assets/69f55e8e-196b-40ae-8fbd-f55e4c2c48a3" />
