### PR TITLE
Only show info panel inside GotR minigame

### DIFF
--- a/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
+++ b/src/main/java/com/datbear/GuardiansOfTheRiftHelperPlugin.java
@@ -233,7 +233,9 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin {
         overlayManager.add(panel);
         overlayManager.add(startTimerOverlay);
         overlayManager.add(portalOverlay);
-        isInMinigame = true;
+        // Initialize presence flags based on current client state instead of defaulting to true
+        isInMinigame = checkInMinigame();
+        isInMainRegion = checkInMainRegion();
 
     }
 
@@ -244,6 +246,9 @@ public class GuardiansOfTheRiftHelperPlugin extends Plugin {
         overlayManager.remove(startTimerOverlay);
         overlayManager.remove(portalOverlay);
         reset();
+        // Clear presence flags on shutdown
+        isInMinigame = false;
+        isInMainRegion = false;
     }
 
     @Subscribe


### PR DESCRIPTION
**Title**
- **Fix**: Only show info panel while inside GotR minigame

**Description**
- **Problem**: The info panel/overlay was appearing everywhere.
- **Cause**: `startUp()` set `isInMinigame = true` unconditionally, so if you enable the plugin while outside of the minigame the info box will stay on your screen.
- **Fix**: Initialize presence flags from runtime checks and clear them on shutdown:
  - Update `startUp()` to call `checkInMinigame()` and `checkInMainRegion()` to set `isInMinigame` and `isInMainRegion`.
  - Update `shutDown()` to set both flags to `false`.

**Why this fixes it**
- The overlays and panel gate their rendering on `isInMainRegion` / `isInMinigame`. Initializing these flags from the client state prevents the overlays from rendering globally when the plugin starts outside the minigame.

**Testing**
- Steps:
  - Build and install or run the plugin in a dev RuneLite instance.
  - Start RuneLite outside GotR and verify the info panel/overlays are not visible.
  - Enter the minigame and verify the panel and overlays appear as expected.
  - Restart RuneLite and ensure behavior persists.
- Optional: enable logging for `checkInMinigame()` / `checkInMainRegion()` if further tracing required.

**Notes**
- This is a minimal behavioral fix that preserves existing logic for detection and rendering; no user-facing config changes required.